### PR TITLE
Use keycodes for normal characters as well

### DIFF
--- a/src/components/remote-control.tsx
+++ b/src/components/remote-control.tsx
@@ -334,16 +334,23 @@ function getAndroidKeycodeAndMeta(event: React.KeyboardEvent): { keycode: number
   const keycode = codeMap[code];
 
   if (!keycode) {
-    // If the physical key code isn't in our map, we can't send a keycode event.
-    // Log the code to potentially add it later if needed.
     console.warn(`Unknown event.code: ${code}, key: ${event.key}`);
     return null;
   }
 
   let metaState = ANDROID_KEYS.META_NONE;
+  const isLetter = code >= 'KeyA' && code <= 'KeyZ';
+  const isCapsLock = event.getModifierState("CapsLock");
+  const isShiftPressed = event.shiftKey;
 
-  // Determine meta state SOLELY based on modifier keys pressed.
-  if (event.shiftKey) metaState |= ANDROID_KEYS.META_SHIFT_ON;
+  // Determine effective shift state
+  let effectiveShift = isShiftPressed;
+  if (isLetter) {
+    effectiveShift = isShiftPressed !== isCapsLock; // Logical XOR for booleans
+  }
+
+  // Apply meta states
+  if (effectiveShift) metaState |= ANDROID_KEYS.META_SHIFT_ON;
   if (event.ctrlKey) metaState |= ANDROID_KEYS.META_CTRL_ON;
   if (event.altKey) metaState |= ANDROID_KEYS.META_ALT_ON;
   if (event.metaKey) metaState |= ANDROID_KEYS.META_META_ON; // Command on Mac, Windows key on Win

--- a/src/components/remote-control.tsx
+++ b/src/components/remote-control.tsx
@@ -54,18 +54,302 @@ const AMOTION_EVENT = {
 } as const;
 
 const ANDROID_KEYS = {
-  ENTER: 66, // KEYCODE_ENTER
-  DEL: 67,   // KEYCODE_DEL (Backspace)
-  FORWARD_DEL: 112, // KEYCODE_FORWARD_DEL (Delete key)
-  MENU: 82,  // KEYCODE_MENU
+  // Actions
+  ACTION_DOWN: 0,
+  ACTION_UP: 1,
+
+  // Meta state flags (from android.view.KeyEvent)
+  META_NONE: 0,
+  META_SHIFT_ON: 1,
+  META_ALT_ON: 2,
+  META_CTRL_ON: 4096, // META_CTRL_LEFT_ON | META_CTRL_RIGHT_ON
+  META_META_ON: 65536, // META_META_LEFT_ON | META_META_RIGHT_ON
+
+  // Keycodes (from android.view.KeyEvent)
+  KEYCODE_UNKNOWN: 0,
+  KEYCODE_SOFT_LEFT: 1,
+  KEYCODE_SOFT_RIGHT: 2,
+  KEYCODE_HOME: 3,
+  KEYCODE_BACK: 4,
+  KEYCODE_CALL: 5,
+  KEYCODE_ENDCALL: 6,
+  KEYCODE_0: 7,
+  KEYCODE_1: 8,
+  KEYCODE_2: 9,
+  KEYCODE_3: 10,
+  KEYCODE_4: 11,
+  KEYCODE_5: 12,
+  KEYCODE_6: 13,
+  KEYCODE_7: 14,
+  KEYCODE_8: 15,
+  KEYCODE_9: 16,
+  KEYCODE_STAR: 17,
+  KEYCODE_POUND: 18,
   DPAD_UP: 19,    // KEYCODE_DPAD_UP
   DPAD_DOWN: 20,  // KEYCODE_DPAD_DOWN
   DPAD_LEFT: 21,  // KEYCODE_DPAD_LEFT
   DPAD_RIGHT: 22, // KEYCODE_DPAD_RIGHT
-  ACTION_DOWN: 0,
-  ACTION_UP: 1,
-  META_NONE: 0,
+  KEYCODE_DPAD_CENTER: 23,
+  KEYCODE_VOLUME_UP: 24,
+  KEYCODE_VOLUME_DOWN: 25,
+  KEYCODE_POWER: 26,
+  KEYCODE_CAMERA: 27,
+  KEYCODE_CLEAR: 28,
+  KEYCODE_A: 29,
+  KEYCODE_B: 30,
+  KEYCODE_C: 31,
+  KEYCODE_D: 32,
+  KEYCODE_E: 33,
+  KEYCODE_F: 34,
+  KEYCODE_G: 35,
+  KEYCODE_H: 36,
+  KEYCODE_I: 37,
+  KEYCODE_J: 38,
+  KEYCODE_K: 39,
+  KEYCODE_L: 40,
+  KEYCODE_M: 41,
+  KEYCODE_N: 42,
+  KEYCODE_O: 43,
+  KEYCODE_P: 44,
+  KEYCODE_Q: 45,
+  KEYCODE_R: 46,
+  KEYCODE_S: 47,
+  KEYCODE_T: 48,
+  KEYCODE_U: 49,
+  KEYCODE_V: 50,
+  KEYCODE_W: 51,
+  KEYCODE_X: 52,
+  KEYCODE_Y: 53,
+  KEYCODE_Z: 54,
+  KEYCODE_COMMA: 55,
+  KEYCODE_PERIOD: 56,
+  KEYCODE_ALT_LEFT: 57,
+  KEYCODE_ALT_RIGHT: 58,
+  KEYCODE_SHIFT_LEFT: 59,
+  KEYCODE_SHIFT_RIGHT: 60,
+  KEYCODE_TAB: 61,
+  KEYCODE_SPACE: 62,
+  KEYCODE_SYM: 63,
+  KEYCODE_EXPLORER: 64,
+  KEYCODE_ENVELOPE: 65,
+  ENTER: 66, // KEYCODE_ENTER
+  DEL: 67,   // KEYCODE_DEL (Backspace)
+  KEYCODE_GRAVE: 68, // `
+  KEYCODE_MINUS: 69, // -
+  KEYCODE_EQUALS: 70, // =
+  KEYCODE_LEFT_BRACKET: 71, // [
+  KEYCODE_RIGHT_BRACKET: 72, // ]
+  KEYCODE_BACKSLASH: 73, // \
+  KEYCODE_SEMICOLON: 74, // ;
+  KEYCODE_APOSTROPHE: 75, // '
+  KEYCODE_SLASH: 76, // /
+  KEYCODE_AT: 77, // @
+  KEYCODE_NUM: 78,
+  KEYCODE_HEADSETHOOK: 79,
+  KEYCODE_FOCUS: 80,
+  KEYCODE_PLUS: 81,
+  MENU: 82,  // KEYCODE_MENU
+  KEYCODE_NOTIFICATION: 83,
+  KEYCODE_SEARCH: 84,
+  KEYCODE_MEDIA_PLAY_PAUSE: 85,
+  KEYCODE_MEDIA_STOP: 86,
+  KEYCODE_MEDIA_NEXT: 87,
+  KEYCODE_MEDIA_PREVIOUS: 88,
+  KEYCODE_MEDIA_REWIND: 89,
+  KEYCODE_MEDIA_FAST_FORWARD: 90,
+  KEYCODE_MUTE: 91,
+  KEYCODE_PAGE_UP: 92,
+  KEYCODE_PAGE_DOWN: 93,
+  KEYCODE_PICTSYMBOLS: 94,
+  KEYCODE_SWITCH_CHARSET: 95,
+  KEYCODE_BUTTON_A: 96,
+  KEYCODE_BUTTON_B: 97,
+  KEYCODE_BUTTON_C: 98,
+  KEYCODE_BUTTON_X: 99,
+  KEYCODE_BUTTON_Y: 100,
+  KEYCODE_BUTTON_Z: 101,
+  KEYCODE_BUTTON_L1: 102,
+  KEYCODE_BUTTON_R1: 103,
+  KEYCODE_BUTTON_L2: 104,
+  KEYCODE_BUTTON_R2: 105,
+  KEYCODE_BUTTON_THUMBL: 106,
+  KEYCODE_BUTTON_THUMBR: 107,
+  KEYCODE_BUTTON_START: 108,
+  KEYCODE_BUTTON_SELECT: 109,
+  KEYCODE_BUTTON_MODE: 110,
+  KEYCODE_ESCAPE: 111,
+  FORWARD_DEL: 112, // KEYCODE_FORWARD_DEL (Delete key)
+  KEYCODE_CTRL_LEFT: 113,
+  KEYCODE_CTRL_RIGHT: 114,
+  KEYCODE_CAPS_LOCK: 115,
+  KEYCODE_SCROLL_LOCK: 116,
+  KEYCODE_META_LEFT: 117,
+  KEYCODE_META_RIGHT: 118,
+  KEYCODE_FUNCTION: 119,
+  KEYCODE_SYSRQ: 120,
+  KEYCODE_BREAK: 121,
+  KEYCODE_MOVE_HOME: 122,
+  KEYCODE_MOVE_END: 123,
+  KEYCODE_INSERT: 124,
+  KEYCODE_FORWARD: 125,
+  KEYCODE_MEDIA_PLAY: 126,
+  KEYCODE_MEDIA_PAUSE: 127,
+  KEYCODE_MEDIA_CLOSE: 128,
+  KEYCODE_MEDIA_EJECT: 129,
+  KEYCODE_MEDIA_RECORD: 130,
+  KEYCODE_F1: 131,
+  KEYCODE_F2: 132,
+  KEYCODE_F3: 133,
+  KEYCODE_F4: 134,
+  KEYCODE_F5: 135,
+  KEYCODE_F6: 136,
+  KEYCODE_F7: 137,
+  KEYCODE_F8: 138,
+  KEYCODE_F9: 139,
+  KEYCODE_F10: 140,
+  KEYCODE_F11: 141,
+  KEYCODE_F12: 142,
+  KEYCODE_NUM_LOCK: 143,
+  KEYCODE_NUMPAD_0: 144,
+  KEYCODE_NUMPAD_1: 145,
+  KEYCODE_NUMPAD_2: 146,
+  KEYCODE_NUMPAD_3: 147,
+  KEYCODE_NUMPAD_4: 148,
+  KEYCODE_NUMPAD_5: 149,
+  KEYCODE_NUMPAD_6: 150,
+  KEYCODE_NUMPAD_7: 151,
+  KEYCODE_NUMPAD_8: 152,
+  KEYCODE_NUMPAD_9: 153,
+  KEYCODE_NUMPAD_DIVIDE: 154,
+  KEYCODE_NUMPAD_MULTIPLY: 155,
+  KEYCODE_NUMPAD_SUBTRACT: 156,
+  KEYCODE_NUMPAD_ADD: 157,
+  KEYCODE_NUMPAD_DOT: 158,
+  KEYCODE_NUMPAD_COMMA: 159,
+  KEYCODE_NUMPAD_ENTER: 160,
+  KEYCODE_NUMPAD_EQUALS: 161,
+  KEYCODE_NUMPAD_LEFT_PAREN: 162,
+  KEYCODE_NUMPAD_RIGHT_PAREN: 163,
+  KEYCODE_VOLUME_MUTE: 164,
+  KEYCODE_INFO: 165,
+  KEYCODE_CHANNEL_UP: 166,
+  KEYCODE_CHANNEL_DOWN: 167,
+  KEYCODE_ZOOM_IN: 168,
+  KEYCODE_ZOOM_OUT: 169,
+  KEYCODE_TV: 170,
+  KEYCODE_WINDOW: 171,
+  KEYCODE_GUIDE: 172,
+  KEYCODE_DVR: 173,
+  KEYCODE_BOOKMARK: 174,
+  KEYCODE_CAPTIONS: 175,
+  KEYCODE_SETTINGS: 176,
+  KEYCODE_TV_POWER: 177,
+  KEYCODE_TV_INPUT: 178,
+  KEYCODE_STB_POWER: 179,
+  KEYCODE_STB_INPUT: 180,
+  KEYCODE_AVR_POWER: 181,
+  KEYCODE_AVR_INPUT: 182,
+  KEYCODE_PROG_RED: 183,
+  KEYCODE_PROG_GREEN: 184,
+  KEYCODE_PROG_YELLOW: 185,
+  KEYCODE_PROG_BLUE: 186,
+  KEYCODE_APP_SWITCH: 187,
+  KEYCODE_LANGUAGE_SWITCH: 204,
+  KEYCODE_ASSIST: 219,
+  KEYCODE_BRIGHTNESS_DOWN: 220,
+  KEYCODE_BRIGHTNESS_UP: 221,
+  KEYCODE_SLEEP: 223,
+  KEYCODE_WAKEUP: 224,
+  KEYCODE_SOFT_SLEEP: 276,
 } as const;
+
+// Map based on event.code for layout independence
+const codeMap: { [code: string]: number } = {
+  'KeyA': ANDROID_KEYS.KEYCODE_A, 'KeyB': ANDROID_KEYS.KEYCODE_B, 'KeyC': ANDROID_KEYS.KEYCODE_C,
+  'KeyD': ANDROID_KEYS.KEYCODE_D, 'KeyE': ANDROID_KEYS.KEYCODE_E, 'KeyF': ANDROID_KEYS.KEYCODE_F,
+  'KeyG': ANDROID_KEYS.KEYCODE_G, 'KeyH': ANDROID_KEYS.KEYCODE_H, 'KeyI': ANDROID_KEYS.KEYCODE_I,
+  'KeyJ': ANDROID_KEYS.KEYCODE_J, 'KeyK': ANDROID_KEYS.KEYCODE_K, 'KeyL': ANDROID_KEYS.KEYCODE_L,
+  'KeyM': ANDROID_KEYS.KEYCODE_M, 'KeyN': ANDROID_KEYS.KEYCODE_N, 'KeyO': ANDROID_KEYS.KEYCODE_O,
+  'KeyP': ANDROID_KEYS.KEYCODE_P, 'KeyQ': ANDROID_KEYS.KEYCODE_Q, 'KeyR': ANDROID_KEYS.KEYCODE_R,
+  'KeyS': ANDROID_KEYS.KEYCODE_S, 'KeyT': ANDROID_KEYS.KEYCODE_T, 'KeyU': ANDROID_KEYS.KEYCODE_U,
+  'KeyV': ANDROID_KEYS.KEYCODE_V, 'KeyW': ANDROID_KEYS.KEYCODE_W, 'KeyX': ANDROID_KEYS.KEYCODE_X,
+  'KeyY': ANDROID_KEYS.KEYCODE_Y, 'KeyZ': ANDROID_KEYS.KEYCODE_Z,
+  'Digit0': ANDROID_KEYS.KEYCODE_0, 'Digit1': ANDROID_KEYS.KEYCODE_1, 'Digit2': ANDROID_KEYS.KEYCODE_2,
+  'Digit3': ANDROID_KEYS.KEYCODE_3, 'Digit4': ANDROID_KEYS.KEYCODE_4, 'Digit5': ANDROID_KEYS.KEYCODE_5,
+  'Digit6': ANDROID_KEYS.KEYCODE_6, 'Digit7': ANDROID_KEYS.KEYCODE_7, 'Digit8': ANDROID_KEYS.KEYCODE_8,
+  'Digit9': ANDROID_KEYS.KEYCODE_9,
+  'Backquote': ANDROID_KEYS.KEYCODE_GRAVE,
+  'Minus': ANDROID_KEYS.KEYCODE_MINUS,
+  'Equal': ANDROID_KEYS.KEYCODE_EQUALS,
+  'BracketLeft': ANDROID_KEYS.KEYCODE_LEFT_BRACKET,
+  'BracketRight': ANDROID_KEYS.KEYCODE_RIGHT_BRACKET,
+  'Backslash': ANDROID_KEYS.KEYCODE_BACKSLASH,
+  'Semicolon': ANDROID_KEYS.KEYCODE_SEMICOLON,
+  'Quote': ANDROID_KEYS.KEYCODE_APOSTROPHE,
+  'Comma': ANDROID_KEYS.KEYCODE_COMMA,
+  'Period': ANDROID_KEYS.KEYCODE_PERIOD,
+  'Slash': ANDROID_KEYS.KEYCODE_SLASH,
+  'Space': ANDROID_KEYS.KEYCODE_SPACE,
+  'Tab': ANDROID_KEYS.KEYCODE_TAB,
+  'Escape': ANDROID_KEYS.KEYCODE_ESCAPE,
+  'ArrowUp': ANDROID_KEYS.DPAD_UP,
+  'ArrowDown': ANDROID_KEYS.DPAD_DOWN,
+  'ArrowLeft': ANDROID_KEYS.DPAD_LEFT,
+  'ArrowRight': ANDROID_KEYS.DPAD_RIGHT,
+  'Enter': ANDROID_KEYS.ENTER,
+  'Backspace': ANDROID_KEYS.DEL,
+  'Delete': ANDROID_KEYS.FORWARD_DEL,
+  'Home': ANDROID_KEYS.KEYCODE_MOVE_HOME,
+  'End': ANDROID_KEYS.KEYCODE_MOVE_END,
+  'PageUp': ANDROID_KEYS.KEYCODE_PAGE_UP,
+  'PageDown': ANDROID_KEYS.KEYCODE_PAGE_DOWN,
+  'Insert': ANDROID_KEYS.KEYCODE_INSERT,
+  'F1': ANDROID_KEYS.KEYCODE_F1, 'F2': ANDROID_KEYS.KEYCODE_F2, 'F3': ANDROID_KEYS.KEYCODE_F3,
+  'F4': ANDROID_KEYS.KEYCODE_F4, 'F5': ANDROID_KEYS.KEYCODE_F5, 'F6': ANDROID_KEYS.KEYCODE_F6,
+  'F7': ANDROID_KEYS.KEYCODE_F7, 'F8': ANDROID_KEYS.KEYCODE_F8, 'F9': ANDROID_KEYS.KEYCODE_F9,
+  'F10': ANDROID_KEYS.KEYCODE_F10, 'F11': ANDROID_KEYS.KEYCODE_F11, 'F12': ANDROID_KEYS.KEYCODE_F12,
+  'ShiftLeft': ANDROID_KEYS.KEYCODE_SHIFT_LEFT, 'ShiftRight': ANDROID_KEYS.KEYCODE_SHIFT_RIGHT,
+  'ControlLeft': ANDROID_KEYS.KEYCODE_CTRL_LEFT, 'ControlRight': ANDROID_KEYS.KEYCODE_CTRL_RIGHT,
+  'AltLeft': ANDROID_KEYS.KEYCODE_ALT_LEFT, 'AltRight': ANDROID_KEYS.KEYCODE_ALT_RIGHT,
+  'MetaLeft': ANDROID_KEYS.KEYCODE_META_LEFT, 'MetaRight': ANDROID_KEYS.KEYCODE_META_RIGHT, // Windows/Command key
+  'ContextMenu': ANDROID_KEYS.MENU, // Often the Menu key
+  // Numpad mappings
+  'Numpad0': ANDROID_KEYS.KEYCODE_NUMPAD_0, 'Numpad1': ANDROID_KEYS.KEYCODE_NUMPAD_1,
+  'Numpad2': ANDROID_KEYS.KEYCODE_NUMPAD_2, 'Numpad3': ANDROID_KEYS.KEYCODE_NUMPAD_3,
+  'Numpad4': ANDROID_KEYS.KEYCODE_NUMPAD_4, 'Numpad5': ANDROID_KEYS.KEYCODE_NUMPAD_5,
+  'Numpad6': ANDROID_KEYS.KEYCODE_NUMPAD_6, 'Numpad7': ANDROID_KEYS.KEYCODE_NUMPAD_7,
+  'Numpad8': ANDROID_KEYS.KEYCODE_NUMPAD_8, 'Numpad9': ANDROID_KEYS.KEYCODE_NUMPAD_9,
+  'NumpadDivide': ANDROID_KEYS.KEYCODE_NUMPAD_DIVIDE,
+  'NumpadMultiply': ANDROID_KEYS.KEYCODE_NUMPAD_MULTIPLY,
+  'NumpadSubtract': ANDROID_KEYS.KEYCODE_NUMPAD_SUBTRACT,
+  'NumpadAdd': ANDROID_KEYS.KEYCODE_NUMPAD_ADD,
+  'NumpadDecimal': ANDROID_KEYS.KEYCODE_NUMPAD_DOT,
+  'NumpadComma': ANDROID_KEYS.KEYCODE_NUMPAD_COMMA, // Some numpads have comma
+  'NumpadEnter': ANDROID_KEYS.KEYCODE_NUMPAD_ENTER,
+  'NumpadEqual': ANDROID_KEYS.KEYCODE_NUMPAD_EQUALS,
+};
+
+function getAndroidKeycodeAndMeta(event: React.KeyboardEvent): { keycode: number, metaState: number } | null {
+  const code = event.code;
+  const keycode = codeMap[code];
+
+  if (!keycode) {
+    // If the physical key code isn't in our map, we can't send a keycode event.
+    // Log the code to potentially add it later if needed.
+    console.warn(`Unknown event.code: ${code}, key: ${event.key}`);
+    return null;
+  }
+
+  let metaState = ANDROID_KEYS.META_NONE;
+
+  // Determine meta state SOLELY based on modifier keys pressed.
+  if (event.shiftKey) metaState |= ANDROID_KEYS.META_SHIFT_ON;
+  if (event.ctrlKey) metaState |= ANDROID_KEYS.META_CTRL_ON;
+  if (event.altKey) metaState |= ANDROID_KEYS.META_ALT_ON;
+  if (event.metaKey) metaState |= ANDROID_KEYS.META_META_ON; // Command on Mac, Windows key on Win
+
+  return { keycode, metaState };
+}
 
 export function RemoteControl({ className, url, token, sessionId: propSessionId, openUrl }: RemoteControlProps) {
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -124,25 +408,6 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
     offset += 4;
 
     view.setInt32(offset, buttons, true);
-    return buffer;
-  };
-
-  const createInjectTextMessage = (text: string) => {
-    const encoder = new TextEncoder();
-    const textBytes = encoder.encode(text);
-    
-    const buffer = new ArrayBuffer(5 + textBytes.length);
-    const view = new DataView(buffer);
-    let offset = 0;
-
-    view.setUint8(offset, CONTROL_MSG_TYPE.INJECT_TEXT);
-    offset += 1;
-
-    view.setUint32(offset, textBytes.length, false);
-    offset += 4;
-
-    new Uint8Array(buffer, offset).set(textBytes);
-
     return buffer;
   };
 
@@ -348,7 +613,7 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
     });
 
     if (document.activeElement !== videoRef.current) {
-      console.warn('Video element not focused');
+      console.warn('Video element not focused, skipping keyboard event');
       return;
     }
 
@@ -357,87 +622,62 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
       return;
     }
 
-    // Handle paste shortcut (Cmd+V on macOS, Ctrl+V on Windows/Linux)
-    if (event.type === 'keydown' && event.key.toLowerCase() === 'v' && (event.metaKey || event.ctrlKey)) {
-      console.log('Paste shortcut detected');
-      
-      // Use the clipboard API to get text
-      navigator.clipboard.readText().then(text => {
-        if (text) {
-          console.log('Pasting text from clipboard API:', text.substring(0, 20) + (text.length > 20 ? '...' : ''));
-          const message = createSetClipboardMessage(text, true);
-          sendBinaryControlMessage(message);
-        }
-      }).catch(err => {
-        console.error('Failed to read clipboard contents: ', err);
-      });
-      return;
-    }
-    // Handle menu shortcut (Cmd+M on macOS, Ctrl+M on Windows/Linux)
-    if (event.type === 'keydown' && event.key.toLowerCase() === 'm' && (event.metaKey || event.ctrlKey)) {
-      console.log('Menu shortcut detected');
-      
-      // Send KEYCODE_MENU down
-      const messageDown = createInjectKeycodeMessage(
-        ANDROID_KEYS.ACTION_DOWN,
-        ANDROID_KEYS.MENU,
-        0,
-        ANDROID_KEYS.META_NONE
-      );
-      sendBinaryControlMessage(messageDown);
-      // Send KEYCODE_MENU up
-      const messageUp = createInjectKeycodeMessage(
-        ANDROID_KEYS.ACTION_UP,
-        ANDROID_KEYS.MENU,
-        0,
-        ANDROID_KEYS.META_NONE
-      );
-      sendBinaryControlMessage(messageUp);
-      return;
-    }
-
-    // Handle arrow keys
-    if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Backspace', 'Delete'].includes(event.key)) {
-      let keycode: number;
-      
-      switch (event.key) {
-        case 'ArrowUp':
-          keycode = ANDROID_KEYS.DPAD_UP;
-          break;
-        case 'ArrowDown':
-          keycode = ANDROID_KEYS.DPAD_DOWN;
-          break;
-        case 'ArrowLeft':
-          keycode = ANDROID_KEYS.DPAD_LEFT;
-          break;
-        case 'ArrowRight':
-          keycode = ANDROID_KEYS.DPAD_RIGHT;
-          break;
-        case 'Enter':
-          keycode = ANDROID_KEYS.ENTER;
-          break;
-        case 'Backspace':
-          keycode = ANDROID_KEYS.DEL;
-          break;
-        case 'Delete':
-          keycode = ANDROID_KEYS.FORWARD_DEL;
-          break;
-        default:
-          return;
+    // Handle special shortcuts first (Paste, Menu)
+    if (event.type === 'keydown') {
+      // Paste (Cmd+V / Ctrl+V)
+      if (event.key.toLowerCase() === 'v' && (event.metaKey || event.ctrlKey)) {
+        console.log('Paste shortcut detected');
+        navigator.clipboard.readText().then(text => {
+          if (text) {
+            console.log('Pasting text via SET_CLIPBOARD:', text.substring(0, 20) + (text.length > 20 ? '...' : ''));
+            const message = createSetClipboardMessage(text, true); // paste=true
+            sendBinaryControlMessage(message);
+          }
+        }).catch(err => {
+          console.error('Failed to read clipboard contents: ', err);
+        });
+        return; // Don't process 'v' keycode further
       }
-      const message = createInjectKeycodeMessage(
-        event.type === 'keydown' ? ANDROID_KEYS.ACTION_DOWN : ANDROID_KEYS.ACTION_UP,
-        keycode,
-        0,
-        ANDROID_KEYS.META_NONE
-      );
-      sendBinaryControlMessage(message);
-      return;
+      
+      // Menu (Cmd+M / Ctrl+M) - Send down and up immediately
+      if (event.key.toLowerCase() === 'm' && (event.metaKey || event.ctrlKey)) {
+        console.log('Menu shortcut detected');
+        const messageDown = createInjectKeycodeMessage(
+          ANDROID_KEYS.ACTION_DOWN,
+          ANDROID_KEYS.MENU,
+          0,
+          ANDROID_KEYS.META_NONE // Modifiers are handled by the shortcut check, not passed down
+        );
+        sendBinaryControlMessage(messageDown);
+        const messageUp = createInjectKeycodeMessage(
+          ANDROID_KEYS.ACTION_UP,
+          ANDROID_KEYS.MENU,
+          0,
+          ANDROID_KEYS.META_NONE
+        );
+        sendBinaryControlMessage(messageUp);
+        return; // Don't process 'm' keycode further
+      }
     }
 
-    if (event.type === 'keydown' && event.key.length === 1) {
-      const message = createInjectTextMessage(event.key);
+    // Handle general key presses (including Arrows, Enter, Backspace, Delete, Letters, Numbers, Symbols)
+    const keyInfo = getAndroidKeycodeAndMeta(event);
+
+    if (keyInfo) {
+      const { keycode, metaState } = keyInfo;
+      const action = event.type === 'keydown' ? ANDROID_KEYS.ACTION_DOWN : ANDROID_KEYS.ACTION_UP;
+      
+      console.log(`Sending Keycode: key=${event.key}, code=${keycode}, action=${action}, meta=${metaState}`);
+
+      const message = createInjectKeycodeMessage(
+        action,
+        keycode,
+        0, // repeat count, typically 0 for single presses
+        metaState
+      );
       sendBinaryControlMessage(message);
+    } else {
+       console.log(`Ignoring unhandled key event: type=${event.type}, key=${event.key}`);
     }
   };
 
@@ -764,4 +1004,4 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
       )}
     </div>
   );
-} 
+}


### PR DESCRIPTION
We used to send `INJECT_TEXT` for non-modifier characters which is interpreted as String in Android/iOS side and mapped to a key code internally with 2 events, `down` and then `up`. However, this is impartial representation of the user input. For example, when user holds `a` key, the receiving end would see repeated `down`+`up` events for `a` key and the resulting behavior may or may not be the same as getting only repeated `down` event when user holds `a` for long period of time.

This PR makes all the keyboard handling rely on INJECT_KEYCODE that supports `down` and `up` action types so that the iOS/Android receives exactly what the user entered.

Note that we solely use Android key codes which get translated into iOS HID key codes internally so that the same `RemoteControl` works for both.