### PR TITLE
Send the release event for mouse/touch even if it happens outside of video area

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ npm install
 npm run dev
 ```
 
+You can run the following in Chrome console to enable debug logging:
+
+```js
+window.debugRemoteControl = true 
+```
+
 ### Releasing
 
 To release a new version, follow these steps:

--- a/src/components/remote-control.tsx
+++ b/src/components/remote-control.tsx
@@ -366,6 +366,10 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
   const [isConnected, setIsConnected] = useState<boolean>(false);
   const keepAliveIntervalRef = useRef<number | undefined>(undefined);
   
+  // Map to track active pointers (mouse or touch) and their last known position inside the video
+  // Key: pointerId (-1 for mouse, touch.identifier for touch), Value: { x: number, y: number }
+  const activePointers = useRef<Map<number, { x: number; y: number }>>(new Map());
+
   const sessionId = useMemo(() => 
     propSessionId || Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15),
     [propSessionId]
@@ -476,12 +480,14 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
 
   const sendBinaryControlMessage = (data: ArrayBuffer) => {
     if (!dataChannelRef.current || dataChannelRef.current.readyState !== 'open') {
+      // console.warn("Data channel not open, cannot send message."); // Reduced verbosity
       return;
     }
     dataChannelRef.current.send(data);
   };
 
-  const handleMouse = (event: React.MouseEvent | React.TouchEvent) => {
+  // Unified handler for both mouse and touch interactions
+  const handleInteraction = (event: React.MouseEvent | React.TouchEvent) => {
     event.preventDefault();
     event.stopPropagation();
 
@@ -489,121 +495,158 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
       return;
     }
 
-    // Skip mousemove events only when no button is pressed (hover events)
-    if (!('touches' in event) && event.type === 'mousemove' && (event as React.MouseEvent).buttons === 0) {
-      return;
-    }
-
     const video = videoRef.current;
     const rect = video.getBoundingClientRect();
-
-    // Get coordinates
-    let clientX: number, clientY: number;
-    if ('touches' in event) {
-      // For touch events, always treat as a tap
-      const touch = event.touches[0] || event.changedTouches[0];
-      clientX = touch.clientX;
-      clientY = touch.clientY;
-    } else if ('clientX' in event) {
-      clientX = event.clientX;
-      clientY = event.clientY;
-    } else {
-      return;
-    }
-
-    // Get the actual video dimensions
     const videoWidth = video.videoWidth;
     const videoHeight = video.videoHeight;
 
-    // Get the display dimensions
-    const displayWidth = rect.width;
-    const displayHeight = rect.height;
+    if (!videoWidth || !videoHeight) return; // Video dimensions not ready
 
-    // Calculate the video's position within its container
-    const videoAspectRatio = videoWidth / videoHeight;
-    const containerAspectRatio = displayWidth / displayHeight;
+    // Helper to process a single pointer event (either mouse or a single touch point)
+    const processPointer = ( 
+      pointerId: number, 
+      clientX: number, 
+      clientY: number, 
+      eventType: 'down' | 'move' | 'up' | 'cancel' 
+    ) => {
 
-    // Calculate the actual dimensions of the video within the container
-    let actualWidth = displayWidth;
-    let actualHeight = displayHeight;
-    if (videoAspectRatio > containerAspectRatio) {
-      // Video is wider than container
-      actualHeight = displayWidth / videoAspectRatio;
-    } else {
-      // Video is taller than container
-      actualWidth = displayHeight * videoAspectRatio;
-    }
-
-    // Calculate the offset of the video within the container
-    const offsetX = (displayWidth - actualWidth) / 2;
-    const offsetY = (displayHeight - actualHeight) / 2;
-
-    // Adjust coordinates relative to the video's actual position
-    const relativeX = clientX - rect.left - offsetX;
-    const relativeY = clientY - rect.top - offsetY;
-
-    // Check if the click is within the actual video area
-    if (
-      relativeX < 0 ||
-      relativeX > actualWidth ||
-      relativeY < 0 ||
-      relativeY > actualHeight
-    ) {
-      return;
-    }
-
-    // Calculate the coordinates in the video's coordinate space
-    const x = (relativeX / actualWidth) * videoWidth;
-    const y = (relativeY / actualHeight) * videoHeight;
-
-    let action: number;
-    if ('touches' in event) {
-      // For touch events
-      switch (event.type) {
-        case 'touchstart':
-          action = AMOTION_EVENT.ACTION_DOWN;
-          break;
-        case 'touchend':
-          action = AMOTION_EVENT.ACTION_UP;
-          break;
-        case 'touchmove':
-          action = AMOTION_EVENT.ACTION_MOVE;
-          break;
-        case 'touchcancel':
-          action = AMOTION_EVENT.ACTION_CANCEL;
-          break;
-        default:
-          return;
+      // --- Start: Coordinate Calculation --- 
+      const displayWidth = rect.width;
+      const displayHeight = rect.height;
+      const videoAspectRatio = videoWidth / videoHeight;
+      const containerAspectRatio = displayWidth / displayHeight;
+      let actualWidth = displayWidth;
+      let actualHeight = displayHeight;
+      if (videoAspectRatio > containerAspectRatio) {
+        actualHeight = displayWidth / videoAspectRatio;
+      } else {
+        actualWidth = displayHeight * videoAspectRatio;
       }
-    } else {
-      // For mouse events
+      const offsetX = (displayWidth - actualWidth) / 2;
+      const offsetY = (displayHeight - actualHeight) / 2;
+      const relativeX = clientX - rect.left - offsetX;
+      const relativeY = clientY - rect.top - offsetY;
+      const isInside = relativeX >= 0 && relativeX <= actualWidth && relativeY >= 0 && relativeY <= actualHeight;
+      
+      let videoX = 0;
+      let videoY = 0;
+      if (isInside) {
+        videoX = Math.max(0, Math.min(videoWidth, (relativeX / actualWidth) * videoWidth));
+        videoY = Math.max(0, Math.min(videoHeight, (relativeY / actualHeight) * videoHeight));
+      }
+      // --- End: Coordinate Calculation ---
+
+      let action: number | null = null;
+      let positionToSend: { x: number; y: number } | null = null;
+      let pressure = 1.0; // Default pressure
+      const buttons = AMOTION_EVENT.BUTTON_PRIMARY; // Assume primary button
+
+      switch (eventType) {
+        case 'down':
+          if (isInside) {
+            action = AMOTION_EVENT.ACTION_DOWN;
+            positionToSend = { x: videoX, y: videoY };
+            activePointers.current.set(pointerId, positionToSend);
+            if (pointerId === -1) { // Focus on mouse down
+              videoRef.current?.focus();
+            }
+          } else {
+            // If the initial down event is outside, ignore it for this pointer
+            activePointers.current.delete(pointerId);
+          }
+          break;
+
+        case 'move':
+          if (activePointers.current.has(pointerId)) {
+            if (isInside) {
+              action = AMOTION_EVENT.ACTION_MOVE;
+              positionToSend = { x: videoX, y: videoY };
+              // Update the last known position for this active pointer
+              activePointers.current.set(pointerId, positionToSend);
+            } else {
+              // Moved outside while active - do nothing, UP/CANCEL will use last known pos
+            }
+          }
+          break;
+
+        case 'up':
+        case 'cancel': // Treat cancel like up, but use ACTION_CANCEL
+          if (activePointers.current.has(pointerId)) {
+            action = (eventType === 'cancel' ? AMOTION_EVENT.ACTION_CANCEL : AMOTION_EVENT.ACTION_UP);
+            // IMPORTANT: Send the UP/CANCEL at the *last known position* inside the video
+            positionToSend = activePointers.current.get(pointerId)!;
+            activePointers.current.delete(pointerId); // Remove pointer as it's no longer active
+          }
+          break;
+      }
+
+      // Send message if action and position determined
+      if (action !== null && positionToSend !== null) {
+        const message = createTouchControlMessage(
+          action,
+          pointerId,
+          positionToSend.x,
+          positionToSend.y,
+          pressure,
+          buttons,
+          buttons
+        );
+        if (message) {
+          sendBinaryControlMessage(message);
+        }
+      } else if (eventType === 'up' || eventType === 'cancel') {
+         // Clean up map just in case if 'down' was outside and 'up'/'cancel' is triggered
+         activePointers.current.delete(pointerId);
+      }
+    };
+
+    // --- Event Type Handling --- 
+
+    if ('touches' in event) { // Touch Events
+      const touches = event.changedTouches; // Use changedTouches for start/end/cancel
+      let eventType: 'down' | 'move' | 'up' | 'cancel';
+
+      switch (event.type) {
+        case 'touchstart': eventType = 'down'; break;
+        case 'touchmove': eventType = 'move'; break;
+        case 'touchend': eventType = 'up'; break;
+        case 'touchcancel': eventType = 'cancel'; break;
+        default: return; // Should not happen
+      }
+
+      for (let i = 0; i < touches.length; i++) {
+        const touch = touches[i];
+        processPointer(touch.identifier, touch.clientX, touch.clientY, eventType);
+      }
+
+    } else { // Mouse Events
+      const pointerId = -1; // Use -1 for mouse pointer
+      let eventType: 'down' | 'move' | 'up' | 'cancel' | null = null;
+
       switch (event.type) {
         case 'mousedown':
-          action = AMOTION_EVENT.ACTION_DOWN;
-          break;
-        case 'mouseup':
-          action = AMOTION_EVENT.ACTION_UP;
+          if (event.button === 0) eventType = 'down'; // Only primary button
           break;
         case 'mousemove':
-          action = AMOTION_EVENT.ACTION_MOVE;
+          // Only process move if primary button is down (check map)
+          if (activePointers.current.has(pointerId)) {
+             eventType = 'move';
+          }
           break;
-        default:
-          return;
+        case 'mouseup':
+          if (event.button === 0) eventType = 'up'; // Only primary button
+          break;
+        case 'mouseleave':
+           // Treat leave like up only if button was down
+           if (activePointers.current.has(pointerId)) {
+              eventType = 'up'; 
+           } 
+          break;
       }
-    }
-
-    const message = createTouchControlMessage(
-      action,
-      -1,
-      x,
-      y,
-      'touches' in event ? 1.0 : 1.0, // Use normal pressure for both touch and mouse
-      AMOTION_EVENT.BUTTON_PRIMARY,
-      AMOTION_EVENT.BUTTON_PRIMARY
-    );
-
-    if (message) {
-      sendBinaryControlMessage(message);
+      
+      if (eventType) {
+        processPointer(pointerId, event.clientX, event.clientY, eventType);
+      }
     }
   };
 
@@ -971,28 +1014,31 @@ export function RemoteControl({ className, url, token, sessionId: propSessionId,
   return (
     <div 
       className={twMerge(clsx("relative flex h-full items-center justify-center bg-muted/90", className))}
-      onTouchStart={handleMouse}
-      onTouchMove={handleMouse}
-      onTouchEnd={handleMouse}
-      onTouchCancel={handleMouse}
-      style={{ touchAction: 'none' }}
+      style={{ touchAction: 'none' }} // Keep touchAction none for the container
+      // Attach unified handler to all interaction events on the container
+      // This helps capture mouseleave correctly even if the video element itself isn't hovered
+      onMouseDown={handleInteraction} 
+      onMouseMove={handleInteraction}
+      onMouseUp={handleInteraction}
+      onMouseLeave={handleInteraction} // Handle mouse leaving the container
+      onTouchStart={handleInteraction}
+      onTouchMove={handleInteraction}
+      onTouchEnd={handleInteraction}
+      onTouchCancel={handleInteraction}
     >
       <video
         ref={videoRef}
-        className="max-h-full h-full max-w-full object-contain"
+        className="max-h-full h-full max-w-full object-contain cursor-none"
         autoPlay
         playsInline
-        tabIndex={0}
-        style={{outline: 'none', touchAction: 'none'}}
-        onMouseDown={handleMouse}
-        onMouseMove={handleMouse}
-        onMouseUp={handleMouse}
+        tabIndex={0} // Make it focusable
+        style={{outline: 'none', pointerEvents: 'none'}}
         onKeyDown={handleKeyboard}
         onKeyUp={handleKeyboard}
         onClick={handleVideoClick}
         onFocus={() => {
           if (videoRef.current) {
-            videoRef.current.style.outline = '2px solid blue';
+            videoRef.current.style.outline = 'none';
           }
         }}
         onBlur={() => {

--- a/src/demo.tsx
+++ b/src/demo.tsx
@@ -1,9 +1,233 @@
-import { StrictMode } from 'react'
+import { StrictMode, useState, useCallback } from 'react'
 import { createRoot } from 'react-dom/client'
 import { RemoteControl } from './components/remote-control'
 
+interface InstanceData {
+  webrtcUrl: string;
+  token: string;
+  name: string;
+}
+
+function InstanceLoader() {
+  const [organizationId, setOrganizationId] = useState<string>("");
+  const [apiToken, setApiToken] = useState<string>("");
+  
+  const [instanceData, setInstanceData] = useState<InstanceData | null>(null);
+  const [appState, setAppState] = useState<'idle' | 'creating' | 'running' | 'stopping' | 'error'>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [currentInstanceName, setCurrentInstanceName] = useState<string>('');
+
+  const generateInstanceName = useCallback(() => {
+      return `ui-demo-${Math.random().toString(36).substring(2, 10)}`;
+  }, []);
+
+  const createInstance = useCallback(async () => {
+    if (!organizationId || !apiToken) {
+      setError("Please enter both Organization ID and API Token.");
+      setAppState('error');
+      return;
+    }
+
+    const instanceName = generateInstanceName();
+    setCurrentInstanceName(instanceName);
+    setAppState('creating');
+    setError(null);
+    
+    try {
+      const apiEndpoint = `https://eu-north1.limbar.net/apis/android.limbar.io/v1alpha1/organizations/${organizationId}/instances`;
+      
+      const response = await fetch(apiEndpoint, {
+        method: 'PUT',
+        headers: {
+          'authorization': `Bearer ${apiToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          instance: {
+            metadata: {
+              name: instanceName, 
+              organizationId: organizationId,
+            },
+            spec: {
+              os: "Android",
+            },
+          },
+          wait: true,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorBody = await response.text();
+        throw new Error(`API Error (${response.status}): ${errorBody}`);
+      }
+
+      const data = await response.json();
+
+      if (data?.metadata?.name !== instanceName) {
+        throw new Error(`API response mismatch: Expected ${instanceName}, got ${data?.metadata?.name}`);
+      }
+
+      if (data?.status?.webrtcUrl && data?.token && data?.status?.state === 'ready') {
+        setInstanceData({
+          webrtcUrl: data.status.webrtcUrl,
+          token: data.token,
+          name: data.metadata.name, 
+        });
+        setAppState('running');
+      } else {
+        throw new Error('Invalid API response format or instance not ready.');
+      }
+    } catch (err) {
+      console.error("Failed to create instance:", err);
+      setError(err instanceof Error ? err.message : String(err));
+      setAppState('error');
+    } 
+  }, [generateInstanceName, organizationId, apiToken]);
+
+  const stopInstance = useCallback(async () => {
+    if (!instanceData || !organizationId || !apiToken) return;
+
+    const instanceNameToDelete = instanceData.name;
+    setAppState('stopping');
+    setError(null);
+
+    try {
+        // Construct endpoint using state
+        const apiEndpoint = `https://eu-north1.limbar.net/apis/android.limbar.io/v1alpha1/organizations/${organizationId}/instances`;
+        const deleteUrl = `${apiEndpoint}/${instanceNameToDelete}`;
+        
+        const response = await fetch(deleteUrl, {
+            method: 'DELETE',
+            headers: {
+                'authorization': `Bearer ${apiToken}`,
+                'content-type': 'application/json',
+            },
+        });
+
+        if (!response.ok) {
+            let errorBody = '';
+            try {
+                errorBody = await response.text();
+            } catch {}
+            if (response.status !== 404) {
+                throw new Error(`API Error (${response.status}): ${errorBody}`);
+            }
+        }
+
+        setInstanceData(null);
+        setAppState('idle');
+
+    } catch (err) {
+        console.error("Failed to stop instance:", err);
+        setError(err instanceof Error ? err.message : `Failed to stop instance ${instanceNameToDelete}. ${String(err)}`);
+        setAppState('error');
+    } 
+  }, [instanceData, organizationId, apiToken]);
+  const showCreateButton = appState === 'idle';
+  const showStopButton = appState === 'running' || appState === 'stopping';
+  const isBusy = appState === 'creating' || appState === 'stopping';
+
+  let mainContent;
+  switch (appState) {
+    case 'creating':
+      mainContent = <p className="text-lg text-gray-600 text-center mt-10">Creating instance ({currentInstanceName})... Please wait.</p>;
+      break;
+    case 'running':
+    case 'stopping':
+      mainContent = (
+        <div className={`relative h-[80vh] w-full overflow-hidden rounded-lg bg-muted/90 shadow-lg ${appState === 'stopping' ? 'opacity-50' : ''}`}>
+          {instanceData && <RemoteControl url={instanceData.webrtcUrl} token={instanceData.token} />} 
+        </div>
+      );
+      break;
+    case 'error':
+      mainContent = (
+        <div className="text-center mt-10 p-4 border border-red-300 bg-red-50 rounded-md">
+          <p className="text-red-700 font-semibold mb-2">Error</p>
+          <p className="text-red-600 mb-4">{error}</p>
+          <button 
+            onClick={() => { setAppState('idle'); setError(null); }}
+            className="px-4 py-2 bg-gray-500 text-white rounded hover:bg-gray-600 transition-colors mr-2"
+          >
+            Dismiss
+          </button>
+        </div>
+      );
+      break;
+    default: // Idle state shows nothing in the main area initially
+      mainContent = <div className="text-center text-gray-500 mt-10">Please enter credentials and click "Create Instance".</div>;
+      break;
+  }
+
+  return (
+    // Changed layout: Inputs/Buttons at top, main content below
+    <div className="w-full max-w-4xl h-full flex flex-col items-center p-5 space-y-6">
+      <h1 className="text-3xl font-bold text-gray-800">Limbar Remote Control Demo</h1>
+      
+      {/* Inputs Section */}
+      <div className="w-full flex flex-col md:flex-row gap-4 p-4 border rounded-lg bg-white shadow-sm">
+        <div className="flex-1">
+          <label htmlFor="orgId" className="block text-sm font-medium text-gray-700 mb-1">Organization ID</label>
+          <input 
+            type="text" 
+            id="orgId" 
+            value={organizationId}
+            onChange={(e) => setOrganizationId(e.target.value)}
+            disabled={isBusy || appState === 'running'}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:bg-gray-100 disabled:cursor-not-allowed"
+            placeholder="e.g., 914173c5-512e..."
+          />
+        </div>
+        <div className="flex-1">
+          <label htmlFor="apiToken" className="block text-sm font-medium text-gray-700 mb-1">API Token</label>
+          <input 
+            id="apiToken" 
+            value={apiToken}
+            onChange={(e) => setApiToken(e.target.value)}
+            disabled={isBusy || appState === 'running'}
+            className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:bg-gray-100 disabled:cursor-not-allowed"
+            placeholder="lim_..."
+          />
+        </div>
+      </div>
+
+      {/* Buttons Section */}
+      <div className="flex gap-4">
+        {showCreateButton && (
+          <button 
+            onClick={createInstance} 
+            disabled={isBusy}
+            className="px-5 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors text-lg shadow disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {isBusy ? 'Processing...' : 'Create Instance'}
+          </button>
+        )}
+        {showStopButton && (
+          <button
+            onClick={stopInstance}
+            disabled={appState === 'stopping'}
+            className="px-5 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 transition-colors shadow disabled:bg-gray-400 disabled:cursor-not-allowed"
+          >
+            {appState === 'stopping' ? 'Stopping...' : `Stop Instance (${instanceData?.name})`}
+          </button>
+        )}
+      </div>
+
+      {/* Main Content Area (Loading / Error / RemoteControl) */}
+      <div className="w-full flex-grow flex justify-center items-center">
+        {mainContent}
+      </div>
+
+    </div>
+  );
+}
+
+// Render the InstanceLoader inside a full-screen container
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <RemoteControl url="http://localhost:8080" token="1234567890" />
+    {/* Use Tailwind for full screen centering */}
+    <div className="h-screen w-screen flex flex-col justify-center items-center bg-gray-100 p-4">
+      <InstanceLoader />
+    </div>
   </StrictMode>,
 )


### PR DESCRIPTION
Otherwise, you'd move out and the Android/iOS instance would look like it's stuck while swiping since it never got the touchup event to finish the swipe action.

Additional changes:
* Merges some of the mouse & touch handling.
* Add instance creation button to demo page so it's easier to test the changes in local dev.

Cases to test (Android & iOS):
* [x] Touch control in a phone where scrolling impacts the emulator, not scroll the whole page.
* [x] Mouse control where mouse goes out of the video and still releases the swipe.
* [x] Shortcuts like ctrl+m and RR for Expo Go.